### PR TITLE
WaitFor improvements:

### DIFF
--- a/PatchLoaderMod/CoroutineHelper.cs
+++ b/PatchLoaderMod/CoroutineHelper.cs
@@ -6,20 +6,61 @@ namespace PatchLoaderMod
 {
     public static class CoroutineHelper
     {
-        public static void WaitFor(Func<bool> predicate, float pollInSec, Action action)
+        public static void WaitFor(Func<bool> predicate, Action success, Action failure, float stopPollingAfterInSec = 60f, float pollRateInSec = 1f)
         {
-            var mb = GameObject.FindObjectOfType<MonoBehaviour>();
-            mb.StartCoroutine(WaitForCoroutine(predicate, pollInSec, action));
+            if (predicate is null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            if (success is null)
+            {
+                throw new ArgumentNullException(nameof(success));
+            }
+
+            if (failure is null)
+            {
+                throw new ArgumentNullException(nameof(failure));
+            }
+            
+            var go = new GameObject();
+            GameObject.DontDestroyOnLoad(go);
+            go.AddComponent<EmptyMonoBehaviour>()
+                .StartCoroutine(
+                    WaitForCoroutine(predicate, success, failure, pollRateInSec, stopPollingAfterInSec, go)
+                );
         }
 
-        private static IEnumerator WaitForCoroutine(Func<bool> predicate, float pollInSec, Action callback)
+        private static IEnumerator WaitForCoroutine(Func<bool> predicate, Action success, Action failure, float pollInSec, float stopPollingAfterInSec, GameObject go)
         {
+            var startTime = Time.time;
+            var stopped = false;
+
             while (!predicate())
             {
+                if (Time.time - startTime >= stopPollingAfterInSec)
+                {
+                    stopped = true;
+                    break;
+                }
+
                 yield return new WaitForSeconds(pollInSec);
             }
 
-            callback();
+            if (stopped)
+            {
+                failure();
+            }
+            else
+            {
+                success();
+            }
+
+            GameObject.Destroy(go);
+        }
+
+        private class EmptyMonoBehaviour : MonoBehaviour
+        {
         }
     }
 }

--- a/PatchLoaderMod/PatchLoaderMod.cs
+++ b/PatchLoaderMod/PatchLoaderMod.cs
@@ -3,6 +3,7 @@ using ColossalFramework.PlatformServices;
 using ColossalFramework.Plugins;
 using ColossalFramework.UI;
 using ICities;
+using System;
 using System.IO;
 using System.Reflection;
 using UnityEngine;
@@ -10,7 +11,8 @@ using Utils;
 
 namespace PatchLoaderMod
 {
-    public class PatchLoaderMod : LoadingExtensionBase, IUserMod {
+    public class PatchLoaderMod : LoadingExtensionBase, IUserMod
+    {
         private DoorstopManager _doorstopManager;
         private PluginManager.PluginInfo _pluginInfo;
         private Utils.Logger _logger;
@@ -20,7 +22,8 @@ namespace PatchLoaderMod
         public string Name => "Patch Loader Mod";
         public string Description => "Automatically loads Patches implementing IPatch API.";
 
-        public void OnEnabled() {
+        public void OnEnabled()
+        {
             _pluginInfo = PluginManager.instance.FindPluginInfo(Assembly.GetExecutingAssembly());
             _logger = new Utils.Logger(Path.Combine(Application.dataPath, "PatchLoaderMod.log"));
             _patchLoderConfigFilePath = Path.Combine(DataLocation.applicationBase, "PatchLoader.Config.xml");
@@ -32,7 +35,7 @@ namespace PatchLoaderMod
                 "PatchLoader.dll"
             );
             _doorstopManager = DoorstopManager.Create(expectedTargetAssemblyPath, _logger);
-            
+
             if (!_doorstopManager.IsInstalled())
             {
                 _doorstopManager.Install();
@@ -77,7 +80,8 @@ namespace PatchLoaderMod
             }
         }
 
-        public void OnDisabled() {
+        public void OnDisabled()
+        {
             if (_doorstopManager.IsInstalled() && !_pluginInfo.isEnabled)
             {
                 _doorstopManager.Disable();
@@ -108,13 +112,18 @@ namespace PatchLoaderMod
         {
             CoroutineHelper.WaitFor(
                 () => UIView.library != null,
-                1f,
-                () => {
+                success: () =>
+                {
                     UIView.library.ShowModal<ExceptionPanel>("ExceptionPanel", (comp, result) =>
                     {
                         LoadingManager.instance.QuitApplication();
                     }).SetMessage("PatchLoaderMod", message, false);
-                }
+                },
+                failure: () =>
+                {
+                    throw new Exception("PatchLoader could not open an important dialog. Something seems to be seriously broken. Please contact the author.");
+                },
+                stopPollingAfterInSec: 30f
             );
         }
     }


### PR DESCRIPTION
added guard clauses.
usage of own gameobject and monobehaviour to make sure there are no sideeffects with other code.
cleanup for own gameobject and monobehaviour.
added a mandatory failure mode so that WaitFor is not going on forever and wasting resources if predicate is never satisfied.
changed parameterlist order so that stopPollingAfterInSec and pollRateInSec can have default values.
fixed minor formatting issues.