### PR TITLE
V.2.0

### DIFF
--- a/Patch.API/Helpers/GameStateUtil.cs
+++ b/Patch.API/Helpers/GameStateUtil.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace Patch.API.Helpers {
+    public static class GameStateUtil {
+        internal static IGameState Util { get; set; }
+        
+        public static bool? IsModEnabled(string workingPath) {
+            return Util.IsModEnabled(workingPath);
+        }
+    }
+}

--- a/Patch.API/Helpers/IGameState.cs
+++ b/Patch.API/Helpers/IGameState.cs
@@ -1,0 +1,5 @@
+namespace Patch.API.Helpers {
+    public interface IGameState {
+        bool? IsModEnabled(string workingPath);
+    }
+}

--- a/Patch.API/IPatch.cs
+++ b/Patch.API/IPatch.cs
@@ -20,7 +20,8 @@ namespace Patch.API
         /// <param name="assemblyDefinition">Assembly definition</param>
         /// <param name="logger">Logger wrapper</param>
         /// <param name="patcherWorkingPath">Patcher directory path - Assembly.GetExecutingAssembly().Location return null (because of )</param>
+        /// <param name="managedDirectoryPath">Managed directory path - path to directory with all game assemblies(completely different on MacOS)</param>
         /// <returns>Modified AssemblyDefinition, used for further processing</returns>
-        AssemblyDefinition Execute(AssemblyDefinition assemblyDefinition, ILogger logger, string patcherWorkingPath);
+        AssemblyDefinition Execute(AssemblyDefinition assemblyDefinition, ILogger logger, string patcherWorkingPath, string managedDirectoryPath);
     }
 }

--- a/Patch.API/IPatch.cs
+++ b/Patch.API/IPatch.cs
@@ -20,8 +20,8 @@ namespace Patch.API
         /// <param name="assemblyDefinition">Assembly definition</param>
         /// <param name="logger">Logger wrapper</param>
         /// <param name="patcherWorkingPath">Patcher directory path - Assembly.GetExecutingAssembly().Location return null (because of )</param>
-        /// <param name="managedDirectoryPath">Managed directory path - path to directory with all game assemblies(completely different on MacOS)</param>
+        /// <param name="gamePaths">All paths that might be necessary for patching the game</param>
         /// <returns>Modified AssemblyDefinition, used for further processing</returns>
-        AssemblyDefinition Execute(AssemblyDefinition assemblyDefinition, ILogger logger, string patcherWorkingPath, string managedDirectoryPath);
+        AssemblyDefinition Execute(AssemblyDefinition assemblyDefinition, ILogger logger, string patcherWorkingPath, IPaths gamePaths);
     }
 }

--- a/Patch.API/IPaths.cs
+++ b/Patch.API/IPaths.cs
@@ -19,6 +19,11 @@ namespace Patch.API {
         /// Path to game's directory Mods folder
         /// </summary>
         string FilesModsPath { get; }
+        
+        /// <summary>
+        /// Path to user AppData folder.
+        /// </summary>
+        string AppDataPath { get; }
 
         /// <summary>
         /// Path to user AppData mods folder.

--- a/Patch.API/IPaths.cs
+++ b/Patch.API/IPaths.cs
@@ -1,0 +1,39 @@
+namespace Patch.API {
+    public interface IPaths {
+        /// <summary>
+        /// Path of internal loader executable, main game directory
+        /// </summary>
+        string WorkingPath { get; }
+
+        /// <summary>
+        /// Path to the PatchLoader assembly.
+        /// </summary>
+        string LoaderPath { get; }
+
+        /// <summary>
+        /// Full path to the game's "Managed" folder that contains all the game's managed assemblies
+        /// </summary>
+        string ManagedFolderPath { get; }
+
+        /// <summary>
+        /// Path to game's directory Mods folder
+        /// </summary>
+        string FilesModsPath { get; }
+
+        /// <summary>
+        /// Path to user AppData mods folder.
+        /// </summary>
+        string AppDataModsPath { get; }
+
+        /// <summary>
+        /// Path to Workshop mods folder, only if PatchLoader was running from workshop directory
+        /// or helper Workshop path was set during mod installation
+        /// </summary>
+        string WorkshopModsPath { get; } //can be null
+
+        /// <summary>
+        /// Path to the Logs folder
+        /// </summary>
+        string LogsPath { get; }
+    }
+}

--- a/Patch.API/Patch.API.csproj
+++ b/Patch.API/Patch.API.csproj
@@ -35,6 +35,7 @@
     <Compile Include="AssemblyToPatch.cs" />
     <Compile Include="ILogger.cs" />
     <Compile Include="IPatch.cs" />
+    <Compile Include="IPaths.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Patch.API/Patch.API.csproj
+++ b/Patch.API/Patch.API.csproj
@@ -33,6 +33,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyToPatch.cs" />
+    <Compile Include="Helpers\GameStateUtil.cs" />
+    <Compile Include="Helpers\IGameState.cs" />
     <Compile Include="ILogger.cs" />
     <Compile Include="IPatch.cs" />
     <Compile Include="IPaths.cs" />

--- a/Patch.API/Properties/AssemblyInfo.cs
+++ b/Patch.API/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/Patch.API/Properties/AssemblyInfo.cs
+++ b/Patch.API/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: InternalsVisibleTo("PatchLoader")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -21,15 +23,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("C5C7F3DD-F203-4510-8525-7EE6FB0E6124")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]

--- a/PatchLoader/EntryPoint.cs
+++ b/PatchLoader/EntryPoint.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using Patch.API.Helpers;
+using PatchLoader.Helpers;
 using Utils;
 using Logger = Utils.Logger;
 
@@ -29,6 +31,10 @@ namespace PatchLoader
             if (_paths.SkipWorkshop) {
                 _logger.Info("******** Workshop mods loading disabled via --noWorkshop commandline argument. Processing workshop mods directories will be skipped ********");
             }
+            
+            SettingsFile.Logger = new WithPrefixLogger(_logger, "PatchLoader.SettingsFile");
+            SettingsFile.LocalAppDataPath = _paths.AppDataPath;
+            GameStateUtil.Util = new GameState();
             
             try {
                 AppDomain.CurrentDomain.TypeResolve += AssemblyResolver;

--- a/PatchLoader/Helpers/GameState.cs
+++ b/PatchLoader/Helpers/GameState.cs
@@ -1,0 +1,13 @@
+using System.IO;
+using Patch.API.Helpers;
+
+namespace PatchLoader.Helpers {
+    internal class GameState: IGameState {
+        public bool? IsModEnabled(string workingPath) {
+            string name = Path.GetFileNameWithoutExtension(workingPath);
+            string key = name + workingPath.GetHashCode().ToString() + ".enabled";
+            SavedBool save = new SavedBool(key, "userGameState");
+            return save.m_Exists ? save.value : (bool?) null;
+        }
+    }
+}

--- a/PatchLoader/Helpers/SavedBool.cs
+++ b/PatchLoader/Helpers/SavedBool.cs
@@ -1,0 +1,20 @@
+﻿namespace PatchLoader.Helpers {
+
+    internal class SavedBool : SavedValue {
+        public readonly bool value;
+        public SavedBool(string name, string fileName) : this(name, fileName, false) { }
+
+        public SavedBool(string name, string fileName, bool def) : base(name, fileName) {
+            value = def;
+            m_Exists = settingsFile.GetValue(name, ref value);
+        }
+
+        public static implicit operator bool(SavedBool s) {
+            return s.value;
+        }
+
+        public override string ToString() {
+            return value.ToString();
+        }
+    }
+}

--- a/PatchLoader/Helpers/SavedFloat.cs
+++ b/PatchLoader/Helpers/SavedFloat.cs
@@ -1,0 +1,21 @@
+﻿namespace PatchLoader.Helpers {
+    
+    internal class SavedFloat : SavedValue {
+        public readonly float value;
+
+        public SavedFloat(string name, string fileName) : this(name, fileName, 0) { }
+
+        public SavedFloat(string name, string fileName, float def) : base(name, fileName) {
+            value = def;
+            m_Exists = settingsFile.GetValue(name, ref value);
+        }
+
+        public static implicit operator float(SavedFloat s) {
+            return s.value;
+        }
+
+        public override string ToString() {
+            return value.ToString();
+        }
+    }
+}

--- a/PatchLoader/Helpers/SavedInt.cs
+++ b/PatchLoader/Helpers/SavedInt.cs
@@ -1,0 +1,21 @@
+﻿namespace PatchLoader.Helpers {
+   
+    internal class SavedInt : SavedValue {
+        public readonly int value;
+
+        public SavedInt(string name, string fileName) : this(name, fileName, 0) { }
+
+        public SavedInt(string name, string fileName, int def) : base(name, fileName) {
+            value = def;
+            m_Exists = settingsFile.GetValue(name, ref value);
+        }
+
+        public static implicit operator int(SavedInt s) {
+            return s.value;
+        }
+
+        public override string ToString() {
+            return value.ToString();
+        }
+    }
+}

--- a/PatchLoader/Helpers/SavedString.cs
+++ b/PatchLoader/Helpers/SavedString.cs
@@ -1,0 +1,22 @@
+﻿namespace PatchLoader.Helpers {
+	
+    internal class SavedString : SavedValue
+	{
+        public readonly string value;
+
+        public SavedString(string name, string fileName) : this(name, fileName, "") { }
+
+        public SavedString(string name, string fileName, string def) : base(name, fileName) {
+            value = def;
+            m_Exists = settingsFile.GetValue(name, ref value);
+        }
+
+        public static implicit operator string(SavedString s) {
+            return s.value;
+        }
+
+        public override string ToString() {
+            return value.ToString();
+        }
+    }
+}

--- a/PatchLoader/Helpers/SavedValue.cs
+++ b/PatchLoader/Helpers/SavedValue.cs
@@ -1,0 +1,44 @@
+﻿namespace PatchLoader.Helpers {
+   
+    internal abstract class SavedValue {
+        public SavedValue(string name, string fileName) {
+            this.name = name;
+            this.m_FileName = fileName;
+        }
+
+        protected string name { get; }
+
+        protected string m_FileName;
+
+        internal bool m_Exists;
+        public bool exists => m_Exists;
+
+        private SettingsFile m_SettingsFile;
+        internal SettingsFile settingsFile => m_SettingsFile ?? (m_SettingsFile = SettingsFile.GetOrLoad(m_FileName));
+
+        public ushort version => settingsFile.version;
+
+        public static bool operator ==(SavedValue x, SavedValue y) {
+            if (object.ReferenceEquals(x, null)) {
+                return object.ReferenceEquals(y, null);
+            }
+            return x.Equals(y);
+        }
+
+        public static bool operator !=(SavedValue x, SavedValue y) {
+            return !(x == y);
+        }
+
+        public override bool Equals(object obj) {
+            return obj != null && ((SavedValue)obj).name == name && ((SavedValue)obj).m_FileName == m_FileName;
+        }
+
+        public bool Equals(SavedValue obj) {
+            return !(obj == null) && obj.name == name && obj.m_FileName == m_FileName;
+        }
+
+        public override int GetHashCode() {
+            return name.GetHashCode() ^ m_FileName.GetHashCode();
+        }
+    }
+}

--- a/PatchLoader/Helpers/SettingsFile.cs
+++ b/PatchLoader/Helpers/SettingsFile.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Patch.API;
+
+namespace PatchLoader.Helpers {
+    internal class SettingsFile {
+        private const string settingsIdentifier = "CGSF";
+        private const string extension = ".cgs";
+        internal static ILogger Logger { get; set; }
+        internal static string LocalAppDataPath { get; set; }
+
+        private static Dictionary<string, SettingsFile> m_SettingsFiles = new Dictionary<string, SettingsFile>();
+
+        internal static void Add(SettingsFile settingsFile) {
+            try {
+                settingsFile.Load();
+                m_SettingsFiles.Add(settingsFile.fileName, settingsFile);
+            } catch (Exception ex) {
+                Logger.Error(ex.ToString());
+            }
+        }
+
+        internal static SettingsFile GetOrLoad(string name) {
+            SettingsFile result;
+            if (!m_SettingsFiles.TryGetValue(name, out result)) {
+                result = new SettingsFile {fileName = name};
+                Add(result);
+            }
+
+            return result;
+        }
+
+        internal ushort version { get; private set; }
+
+        private Dictionary<string, int> m_SettingsIntValues = new Dictionary<string, int>();
+
+        private Dictionary<string, bool> m_SettingsBoolValues = new Dictionary<string, bool>();
+
+        private Dictionary<string, float> m_SettingsFloatValues = new Dictionary<string, float>();
+
+        private Dictionary<string, string> m_SettingsStringValues = new Dictionary<string, string>();
+
+        internal string pathName { get; private set; }
+
+        internal string fileName {
+            get { return Path.GetFileNameWithoutExtension(pathName); }
+            set {
+                string path = LocalAppDataPath;
+                path = Path.Combine(path, value);
+                if (!path.EndsWith(extension))
+                    path += extension;
+                pathName = path;
+            }
+        }
+
+        internal Stream CreateReadStream() {
+            return new FileStream(pathName, FileMode.Open, FileAccess.Read);
+        }
+
+        internal bool IsValid() => !string.IsNullOrEmpty(pathName) && File.Exists(pathName);
+
+        private bool ValidateID(char[] id) {
+            for (int i = 0; i < 4; i++) {
+                if (id[i] != settingsIdentifier[i])
+                    return false;
+            }
+
+            return true;
+        }
+
+        private void Deserialize(Stream stream) {
+            using (BinaryReader binaryReader = new BinaryReader(stream)) {
+                if (ValidateID(binaryReader.ReadChars(4))) {
+                    version = binaryReader.ReadUInt16();
+
+                    lock (m_SettingsIntValues) {
+                        m_SettingsIntValues.Clear();
+                        int num = binaryReader.ReadInt32();
+                        for (int i = 0; i < num; i++) {
+                            string key = binaryReader.ReadString();
+                            int value = binaryReader.ReadInt32();
+                            m_SettingsIntValues.Add(key, value);
+                        }
+                    }
+
+                    lock (m_SettingsBoolValues) {
+                        m_SettingsBoolValues.Clear();
+                        int num2 = binaryReader.ReadInt32();
+                        for (int j = 0; j < num2; j++) {
+                            string key2 = binaryReader.ReadString();
+                            bool value2 = binaryReader.ReadBoolean();
+                            m_SettingsBoolValues.Add(key2, value2);
+                        }
+                    }
+
+                    lock (m_SettingsFloatValues) {
+                        m_SettingsFloatValues.Clear();
+                        int num3 = binaryReader.ReadInt32();
+                        for (int k = 0; k < num3; k++) {
+                            string key3 = binaryReader.ReadString();
+                            float value3 = binaryReader.ReadSingle();
+                            m_SettingsFloatValues.Add(key3, value3);
+                        }
+                    }
+
+                    lock (m_SettingsStringValues) {
+                        m_SettingsStringValues.Clear();
+                        int num4 = binaryReader.ReadInt32();
+                        for (int l = 0; l < num4; l++) {
+                            string key4 = binaryReader.ReadString();
+                            string value4 = binaryReader.ReadString();
+                            m_SettingsStringValues.Add(key4, value4);
+                        }
+                    }
+
+                    return;
+                }
+
+                throw new Exception("Setting file '" + fileName + "' header mismatch.");
+            }
+        }
+
+        internal void Load() {
+            if (IsValid()) {
+                Logger.Info("Loading " + pathName);
+                using (Stream stream = CreateReadStream()) {
+                    Deserialize(stream);
+                }
+            } else {
+                Logger.Info(pathName + " does not exists");
+            }
+        }
+
+
+        internal bool GetValue(string name, out object v) {
+            int num;
+            if (m_SettingsIntValues.TryGetValue(name, out num)) {
+                v = num;
+                return true;
+            }
+
+            bool flag;
+            if (m_SettingsBoolValues.TryGetValue(name, out flag)) {
+                v = flag;
+                return true;
+            }
+
+            string text;
+            if (m_SettingsStringValues.TryGetValue(name, out text)) {
+                v = text;
+                return true;
+            }
+
+            float num2;
+            if (m_SettingsFloatValues.TryGetValue(name, out num2)) {
+                v = num2;
+                return true;
+            }
+
+            v = null;
+            return false;
+        }
+
+        internal bool GetValue(string name, ref string val) {
+            string text;
+            if (m_SettingsStringValues.TryGetValue(name, out text)) {
+                val = text;
+                return true;
+            }
+
+            return false;
+        }
+
+        internal bool GetValue(string name, ref bool val) {
+            bool flag;
+            if (m_SettingsBoolValues.TryGetValue(name, out flag)) {
+                val = flag;
+                return true;
+            }
+
+            return false;
+        }
+
+
+        internal bool GetValue(string name, ref int val) {
+            int num;
+            if (m_SettingsIntValues.TryGetValue(name, out num)) {
+                val = num;
+                return true;
+            }
+
+            return false;
+        }
+
+        internal bool GetValue(string name, ref float val) {
+            float num;
+            if (m_SettingsFloatValues.TryGetValue(name, out num)) {
+                val = num;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/PatchLoader/PatchLoader.csproj
+++ b/PatchLoader/PatchLoader.csproj
@@ -39,6 +39,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EntryPoint.cs" />
+    <Compile Include="Helpers\GameState.cs" />
+    <Compile Include="Helpers\SavedBool.cs" />
+    <Compile Include="Helpers\SavedFloat.cs" />
+    <Compile Include="Helpers\SavedInt.cs" />
+    <Compile Include="Helpers\SavedString.cs" />
+    <Compile Include="Helpers\SavedValue.cs" />
+    <Compile Include="Helpers\SettingsFile.cs" />
     <Compile Include="InternalLoader.cs" />
     <Compile Include="PatchProcessor.cs" />
     <Compile Include="PatchScanner.cs" />

--- a/PatchLoader/PatchProcessor.cs
+++ b/PatchLoader/PatchProcessor.cs
@@ -36,7 +36,7 @@ namespace PatchLoader
                 {
                     PatchLoaderStatusInfo.Statuses.Add(status.PatchName, status);
                     _logger.Info($"Executing patch {assemblyName} of {keyValuePair.Key}\n");
-                    _assemblies[assemblyName] = patch.Execute(definition, new WithPrefixLogger(_logger, assemblyName), Path.GetDirectoryName(keyValuePair.Key), paths.ManagedFolderPath);
+                    _assemblies[assemblyName] = patch.Execute(definition, new WithPrefixLogger(_logger, assemblyName), Path.GetDirectoryName(keyValuePair.Key), paths);
                 }
                 catch (Exception e)
                 {

--- a/PatchLoader/PatchProcessor.cs
+++ b/PatchLoader/PatchProcessor.cs
@@ -36,7 +36,7 @@ namespace PatchLoader
                 {
                     PatchLoaderStatusInfo.Statuses.Add(status.PatchName, status);
                     _logger.Info($"Executing patch {assemblyName} of {keyValuePair.Key}\n");
-                    _assemblies[assemblyName] = patch.Execute(definition, new WithPrefixLogger(_logger, assemblyName), Path.GetDirectoryName(keyValuePair.Key));
+                    _assemblies[assemblyName] = patch.Execute(definition, new WithPrefixLogger(_logger, assemblyName), Path.GetDirectoryName(keyValuePair.Key), paths.ManagedFolderPath);
                 }
                 catch (Exception e)
                 {

--- a/PatchLoader/PatchScanner.cs
+++ b/PatchLoader/PatchScanner.cs
@@ -24,7 +24,7 @@ namespace PatchLoader {
                 string[] directories = Directory.GetDirectories(path, "*");
                 for (var i = 0; i < directories.Length; i++) {
                     if (!Path.GetFileName(directories[i]).StartsWith("_")) {
-                        assemblies.AddRange(Directory.GetFiles(directories[i], "*.dll", SearchOption.AllDirectories));
+                        assemblies.AddRange(GetFiles(directories[i], "*.ipatch", SearchOption.AllDirectories));
                     } else {
                         _logger.Info($"Ignored Inactive mod path {directories[i]}");
                     }
@@ -100,6 +100,16 @@ namespace PatchLoader {
             }
 
             return hit;
+        }
+        
+        public static string[] GetFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            string[] searchPatterns = searchPattern.Split('|');
+            List<string> files = new List<string>();
+            foreach (string sp in searchPatterns)
+                files.AddRange(Directory.GetFiles(path, sp, searchOption));
+            files.Sort();
+            return files.ToArray();
         }
     }
 }

--- a/PatchLoader/Paths.cs
+++ b/PatchLoader/Paths.cs
@@ -45,7 +45,7 @@ namespace PatchLoader {
 
             var appDataModsPath = "";
             if (isMac) {
-                appDataModsPath = PathExtensions.Combine(new DirectoryInfo(workingPath).Parent.Parent.FullName, "Addons", "Mods");
+                appDataModsPath = PathExtensions.Combine(new DirectoryInfo(workingPath).Parent.Parent.Parent.Parent.Parent.Parent.FullName, "Colossal Order", "Cities_Skylines", "Addons", "Mods");
             } else {
                 appDataModsPath = PathExtensions.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Colossal Order", "Cities_Skylines", "Addons", "Mods");
             }

--- a/PatchLoader/Paths.cs
+++ b/PatchLoader/Paths.cs
@@ -14,11 +14,13 @@ namespace PatchLoader {
             string loaderPath,
             string managedFolderPath,
             string filesModsPath,
+            string appDataPath,
             string appDataModsPath) {
             WorkingPath = workingPath ?? throw new ArgumentNullException(nameof(workingPath));
             LoaderPath = loaderPath ?? throw new ArgumentNullException(nameof(loaderPath));
             ManagedFolderPath = managedFolderPath ?? throw new ArgumentNullException(nameof(managedFolderPath));
             FilesModsPath = filesModsPath ?? throw new ArgumentNullException(nameof(filesModsPath));
+            AppDataPath = appDataPath ?? throw new ArgumentNullException(nameof(appDataPath));
             AppDataModsPath = appDataModsPath ?? throw new ArgumentNullException(nameof(appDataModsPath));
             SkipWorkshop = Environment.GetCommandLineArgs().Any(command => command.Equals("--noWorkshop"));
             DisableMods = Environment.GetCommandLineArgs().Any(command => command.Equals("--disableMods"));
@@ -42,19 +44,22 @@ namespace PatchLoader {
             } else {
                 filesModsPath = PathExtensions.Combine(workingPath, "Files", "Mods");
             }
-
-            var appDataModsPath = "";
+            
+            var appDataPath = "";
             if (isMac) {
-                appDataModsPath = PathExtensions.Combine(new DirectoryInfo(workingPath).Parent.Parent.Parent.Parent.Parent.Parent.FullName, "Colossal Order", "Cities_Skylines", "Addons", "Mods");
+                appDataPath = PathExtensions.Combine(new DirectoryInfo(workingPath).Parent.Parent.Parent.Parent.Parent.Parent.FullName, "Colossal Order", "Cities_Skylines");
             } else {
-                appDataModsPath = PathExtensions.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Colossal Order", "Cities_Skylines", "Addons", "Mods");
+                appDataPath = PathExtensions.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Colossal Order", "Cities_Skylines");
             }
+
+            var appDataModsPath = PathExtensions.Combine(appDataPath, "Addons", "Mods");
 
             return new Paths(
                 workingPath,
                 loaderPath,
                 managedFolderPath,
                 filesModsPath,
+                appDataPath,
                 appDataModsPath);
         }
 
@@ -82,6 +87,11 @@ namespace PatchLoader {
         /// Path to user AppData mods folder.
         /// </summary>
         public string AppDataModsPath { get; }
+
+        /// <summary>
+        /// Path to user AppData folder.
+        /// </summary>
+        public string AppDataPath { get; }
 
         /// <summary>
         /// Path to Workshop mods folder.

--- a/PatchLoader/Paths.cs
+++ b/PatchLoader/Paths.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Patch.API;
 using Utils;
 
 namespace PatchLoader {
-    public class Paths {
+    public class Paths : IPaths {
         //use static factory method 'Create()' instead
         private Paths(
             string workingPath,

--- a/PatchLoader/Properties/AssemblyInfo.cs
+++ b/PatchLoader/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/PatchLoaderMod/Doorstop/DoorstopManager.cs
+++ b/PatchLoaderMod/Doorstop/DoorstopManager.cs
@@ -98,8 +98,7 @@ namespace PatchLoaderMod.Doorstop {
                     (this as LinuxDoorstopManager)?.GrantExecuteAccessForConfig();
                     RequiresRestart = true;
                 } else if (platform == RuntimePlatform.OSXPlayer) {
-                    //todo add support for MacOS
-                    //(this as MacOSDoorstopManager)?.GrantExecuteAccessForConfig();
+                    (this as MacOSDoorstopManager)?.GrantExecuteAccessForConfig();
                 }
             } else {
                 RequiresRestart = true;

--- a/PatchLoaderMod/Doorstop/LinuxDoorstopManager.cs
+++ b/PatchLoaderMod/Doorstop/LinuxDoorstopManager.cs
@@ -14,12 +14,23 @@ namespace PatchLoaderMod.Doorstop {
 
         public override string InstallMessage { get; } = "The game will be closed.\n\n" +
                                                          "\tIMPORTANT!\n\n" +
-                                                         "To make it work, add './Cities_Loader.sh %command%' (without quotes) to the game Steam Set Launch Options\n" +
-                                                         "If game won't launch, remove it to run game normally";
+                                                         "If you use Paradox game launcher:\n" +
+                                                         "  1. Open main game directory and search for launcher-settings.json\n" +
+                                                         "  2. Make backup of that file (e.g. create copy with different name)\n" +
+                                                         "  3. Open launcher-settings.json with any text editor and change\n" +
+                                                         "  'exePath' value to './Cities_Loader.sh' ('Cities.x64' is the default)\n" +
+                                                         "  4. Save file and run game normally\n\n" +
+                                                         "---------------------------------------------------------------------\n" +
+                                                         "If you don't use Paradox game launcher:\n" +
+                                                         "  1. Add './Cities_Loader.sh %command%' (without quotes) to the game Steam Set Launch Options\n" +
+                                                         "  2. Run game normally\n" +
+                                                         "---------------------------------------------------------------------\n" +
+                                                         "If game won't launch, remove parameter or restore backup launcher-settings.json to run game normally\n" +
+                                                         "and contact the mod author for more solutions";
 
         public override string UninstallMessage { get; } = "The game will be closed.\n\n" +
                                                            "\tIMPORTANT!\n\n" +
-                                                           "Clear parameters from Steam Set Launch Options if any in order to run game!\n";
+                                                           "Clear parameters from Steam Set Launch Options if any or restore backup launcher-settings.json\n in order to run game!\n";
 
         private UnixConfigProperties _configProperties = new UnixConfigProperties(
             "#!/bin/sh\n" +
@@ -28,7 +39,7 @@ namespace PatchLoaderMod.Doorstop {
             "export LD_LIBRARY_PATH=${doorstop_dir}:${LD_LIBRARY_PATH};\nexport LD_PRELOAD=$doorstop_libname;",
             "export DOORSTOP_ENABLE",
             "export DOORSTOP_INVOKE_DLL_PATH",
-            "./Cities.x64"
+            "./Cities.x64 $@"
         );
 
         public LinuxDoorstopManager(string expectedTargetAssemblyPath, Logger logger) : base(expectedTargetAssemblyPath, logger) {

--- a/PatchLoaderMod/Doorstop/MacOSDoorstopManager.cs
+++ b/PatchLoaderMod/Doorstop/MacOSDoorstopManager.cs
@@ -9,13 +9,11 @@ namespace PatchLoaderMod.Doorstop {
     public class MacOSDoorstopManager: DoorstopManager {
         public override string LoaderMD5 => "806bb7ee34f2506de077d6a6b18fec44";
         public override bool RequiresRestart { get; protected set; } = false;
-        public override bool PlatformSupported => false;
-        //todo uncomment when fixed
-        // public override string InstallMessage { get; } = "The game will be closed.\n\nIMPORTANT!\n\nAdd './Cities_Loader.sh %command%' (without quotes) to the game Steam Set Launch Options";
-        public override string InstallMessage { get; } = "\tMacOS IS NOT SUPPORTED YET!\n\n";
+        public override bool PlatformSupported => true;
+        public override string InstallMessage { get; } = "The game will be closed.\n\nIMPORTANT!\n\nAdd './Cities_Loader.sh %command%' (without quotes) to the game Steam Set Launch Options";
         public override string UninstallMessage { get; } = "The game will be closed.\n\n";
 
-        public override bool CanEnable { get; } = false;
+        public override bool CanEnable { get; } = true;
 
         private UnixConfigProperties _configProperties = new UnixConfigProperties(
             "#!/bin/sh\n" +

--- a/PatchLoaderMod/Doorstop/MacOSDoorstopManager.cs
+++ b/PatchLoaderMod/Doorstop/MacOSDoorstopManager.cs
@@ -10,7 +10,25 @@ namespace PatchLoaderMod.Doorstop {
         public override string LoaderMD5 => "806bb7ee34f2506de077d6a6b18fec44";
         public override bool RequiresRestart { get; protected set; } = false;
         public override bool PlatformSupported => true;
-        public override string InstallMessage { get; } = "The game will be closed.\n\nIMPORTANT!\n\nAdd './Cities_Loader.sh %command%' (without quotes) to the game Steam Set Launch Options";
+
+        public override string InstallMessage { get; } = "The game will be closed.\n\n" +
+                                                         "\tIMPORTANT!\n\n" +
+                                                         "If you use Paradox game launcher:\n" +
+                                                         "  1. Open main game directory (Cities.app) navigate to " +
+                                                         "     /Contents/Launcher directory and search for launcher-settings.json\n" +
+                                                         "  2. Make backup of that file (e.g. create copy with different name)\n" +
+                                                         "  3. Open launcher-settings.json with any text editor and change" +
+                                                         " 'exePath' value to '../../../Cities_Loader.sh' instead of" +
+                                                         " original '../MacOS/Cities' instead of original '../MacOS/Cities'\n" +
+                                                         "  4. Save file and run game normally\n\n" +
+                                                         "---------------------------------------------------------------------\n" +
+                                                         "If don't use Paradox game launcher:\n" +
+                                                         "  1. Add './Cities_Loader.sh %command%' (without quotes) to the game Steam Set Launch Options\n" +
+                                                         "    in the Steam Client\n" +
+                                                         "  2. Run game normally\n" +
+                                                         "---------------------------------------------------------------------\n" +
+                                                         "If game won't launch remove commandline parameter or restore backup launcher-settings.json\n" +
+                                                         "and contact the mod author for more solutions";
         public override string UninstallMessage { get; } = "The game will be closed.\n\n";
 
         public override bool CanEnable { get; } = true;
@@ -23,7 +41,7 @@ namespace PatchLoaderMod.Doorstop {
                     "export DYLD_INSERT_LIBRARIES=$doorstop_libname;",
             "export DOORSTOP_ENABLE",
             "export DOORSTOP_INVOKE_DLL_PATH",
-            "./Cities.app/Contents/MacOS/Cities"
+            "./Cities.app/Contents/MacOS/Cities $@"
         );
 
         public MacOSDoorstopManager(string expectedTargetAssemblyPath, Logger logger) : base(expectedTargetAssemblyPath, logger) {

--- a/PatchLoaderMod/DoorstopUpgrade/MacOSUpgrade.cs
+++ b/PatchLoaderMod/DoorstopUpgrade/MacOSUpgrade.cs
@@ -9,8 +9,7 @@ namespace PatchLoaderMod.DoorstopUpgrade {
         public UpgradeState State { get; private set; }
 
         public void UpdateState() {
-            _logger.Error("Update State not implemented for MacOS");
-            State = UpgradeState.Error;
+            State = UpgradeState.Latest;
         }
 
         public void SetDoorstopManager(DoorstopManager manager) {

--- a/PatchLoaderMod/Properties/AssemblyInfo.cs
+++ b/PatchLoaderMod/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.3.*")]
+[assembly: AssemblyVersion("2.0.0.*")]
 // [assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Breaking changes in v. 2.0
---
```diff
- AssemblyDefinition Execute(AssemblyDefinition assemblyDefinition, ILogger logger, string patcherWorkingPath, string managedDirectoryPath)
+ AssemblyDefinition Execute(AssemblyDefinition assemblyDefinition, ILogger logger, string patcherWorkingPath, IPaths gamePaths)`
```
Dropped support for `*.dll` patches, only `*.ipatch` extension is supported (no need to include API.dll or Mono.Cecil.dll)

---
- compatibility with MacOS
- assembly version update,
- improved detection of local mods directory on MacOS
- support for testing if mod is enabled by searching for mod entry in userGameState.cgs config
- support for non-modifying patches (`null` PatchTarget)
- improved install message for Linux and MacOS, …
- changed Statuses list

Closes #8 