### PR TITLE
MacOs local mod directory detection, fixed noWorkshop, disableMods flags  

### DIFF
--- a/PatchLoader/Paths.cs
+++ b/PatchLoader/Paths.cs
@@ -23,8 +23,8 @@ namespace PatchLoader {
             FilesModsPath = filesModsPath ?? throw new ArgumentNullException(nameof(filesModsPath));
             AppDataPath = appDataPath ?? throw new ArgumentNullException(nameof(appDataPath));
             AppDataModsPath = appDataModsPath ?? throw new ArgumentNullException(nameof(appDataModsPath));
-            SkipWorkshop = Environment.GetCommandLineArgs().Any(command => command.Equals("--noWorkshop"));
-            DisableMods = Environment.GetCommandLineArgs().Any(command => command.Equals("--disableMods"));
+            SkipWorkshop = Environment.GetCommandLineArgs().Any(command => command.Contains("-noWorkshop"));
+            DisableMods = Environment.GetCommandLineArgs().Any(command => command.Contains("-disableMods"));
             SetupLogsDirectoryPath();
         }
 
@@ -49,7 +49,7 @@ namespace PatchLoader {
             
             var appDataPath = "";
             if (isMac) {
-                appDataPath = PathExtensions.Combine(new DirectoryInfo(workingPath).Parent.Parent.Parent.Parent.Parent.Parent.FullName, "Colossal Order", "Cities_Skylines");
+                appDataPath = PathExtensions.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library"), "Application Support", "Colossal Order", "Cities_Skylines");
             } else {
                 appDataPath = PathExtensions.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Colossal Order", "Cities_Skylines");
             }

--- a/PatchLoader/Properties/AssemblyInfo.cs
+++ b/PatchLoader/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.1.0.1")]
+[assembly: AssemblyFileVersion("2.1.0.1")]

--- a/PatchLoaderMod/Doorstop/LinuxDoorstopManager.cs
+++ b/PatchLoaderMod/Doorstop/LinuxDoorstopManager.cs
@@ -18,7 +18,7 @@ namespace PatchLoaderMod.Doorstop {
                                                          "  1. Open main game directory and search for launcher-settings.json\n" +
                                                          "  2. Make backup of that file (e.g. create copy with different name)\n" +
                                                          "  3. Open launcher-settings.json with any text editor and change\n" +
-                                                         "  'exePath' value to './Cities_Loader.sh' ('Cities.x64' is the default)\n" +
+                                                         "  'exePath' value to 'Cities_Loader.sh' ('Cities.x64' is the default)\n" +
                                                          "  4. Save file and run game normally\n\n" +
                                                          "---------------------------------------------------------------------\n" +
                                                          "If you don't use Paradox game launcher:\n" +

--- a/PatchLoaderMod/PatchLoaderMod.cs
+++ b/PatchLoaderMod/PatchLoaderMod.cs
@@ -22,7 +22,7 @@ namespace PatchLoaderMod
         private string _patchLoaderConfigFilePath;
         private ConfigManager<Config> _configManager;
 
-        public string Name => "Patch Loader Mod v2.1.1";
+        public string Name => "Patch Loader Mod v2.1.2";
         public string Description => "Automatically loads Patches implementing IPatch API.";
         private SettingsUi _settingsUi;
         private static bool gameVersionSupported = true;

--- a/PatchLoaderMod/Properties/AssemblyInfo.cs
+++ b/PatchLoaderMod/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.1.*")]
+[assembly: AssemblyVersion("2.1.2.*")]
 // [assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
**v. 2.1.2**

- fixed problem with detection of `-noWorkshop` and `-disableMods` flags, 
- improved local mods directory path detection on `MacOS`