### PR TITLE
Don't leave an extra shell open on Linux/macOS

### DIFF
--- a/PatchLoaderMod/Doorstop/LinuxDoorstopManager.cs
+++ b/PatchLoaderMod/Doorstop/LinuxDoorstopManager.cs
@@ -40,7 +40,7 @@ namespace PatchLoaderMod.Doorstop {
             "export LD_PRELOAD",
             "export DOORSTOP_ENABLE",
             "export DOORSTOP_INVOKE_DLL_PATH",
-            "./Cities.x64 $@"
+            "exec ./Cities.x64 $@"
         );
 
         public LinuxDoorstopManager(string expectedTargetAssemblyPath, Logger logger) : base(expectedTargetAssemblyPath, logger) {

--- a/PatchLoaderMod/Doorstop/MacOSDoorstopManager.cs
+++ b/PatchLoaderMod/Doorstop/MacOSDoorstopManager.cs
@@ -43,7 +43,7 @@ namespace PatchLoaderMod.Doorstop {
             "export DYLD_INSERT_LIBRARIES",
             "export DOORSTOP_ENABLE",
             "export DOORSTOP_INVOKE_DLL_PATH",
-            "./Cities.app/Contents/MacOS/Cities $@"
+            "exec ./Cities.app/Contents/MacOS/Cities $@"
         );
 
         public MacOSDoorstopManager(string expectedTargetAssemblyPath, Logger logger) : base(expectedTargetAssemblyPath, logger) {


### PR DESCRIPTION
`exec` can be used before a command to replace the shell process with the next command. It is commonly used at the end of scripts to save having to create a new process. This change should save a tiny bit of memory.

# Before

```
home@daniel-desktop3:~$ ps -ef | grep Loader
home       24040   23833  0 18:18 ?        00:00:00 /bin/sh -c ./'Cities_Loader.sh' '--no-sandbox'
home       24041   24040  0 18:18 ?        00:00:00 /bin/sh ./Cities_Loader.sh --no-sandbox
home       24279   24231  0 18:18 pts/4    00:00:00 grep Loader
```

# After

```
home@daniel-desktop3:~$ ps -ef | grep Loader
home       25315   25142  0 18:20 ?        00:00:00 /bin/sh -c ./'Cities_Loader.sh' '--no-sandbox'
home       25462   24231  0 18:20 pts/4    00:00:00 grep Loader
```